### PR TITLE
CSVファイルをパースした際に「no subject」となった場合、コンソールへそのファイル名を出力するようにした

### DIFF
--- a/src/kdb.ts
+++ b/src/kdb.ts
@@ -37,7 +37,7 @@ const getSubjectRecords = async (flow: FlowType, hierarchy: Hierarchy) => {
     const downloadFlow = await endpoints.kdb.outputCsv(newFlow, hierarchy);
     const csv = await endpoints.getContent(downloadFlow, "shift-jis");
 
-    const categories = getSubjectsRecord(csv);
+    const categories = getSubjectsRecord(csv, `${hierarchy.serialize()}.csv`);
 
     const subCategories = buildKdbSubCategories(categories);
     const subjects = createLeafResultNode(hierarchy, subCategories);

--- a/src/parser/parseCsv.ts
+++ b/src/parser/parseCsv.ts
@@ -1,7 +1,7 @@
 import { commonHeader, SubjectRecord } from "../util/subjectRecord.js";
 import { ParsedKdbTableType } from "./types.js";
 
-const parseLine = (line: string, i: number) => {
+const parseLine = (line: string, i: number, fileName?: string) => {
     const tokens = line.trim().split('"');
     const records: string[][] = [];
     let state = "start"; // 'start' | 'text' | 'mid'
@@ -39,17 +39,17 @@ const parseLine = (line: string, i: number) => {
     return records.map((v) => v.join('"'));
 };
 
-export const getSubjectsRecord = (csvStr: string): ParsedKdbTableType => {
+export const getSubjectsRecord = (csvStr: string, fileName?: string): ParsedKdbTableType => {
     const lines = csvStr.split("\n");
     if (lines.length === 3) {
-        console.log("* no subject");
+        console.log(`* no subject in file: ${fileName || 'unknown'}`);
         return [];
     }
     if (lines.length < 3) {
         throw "! unknown";
     }
 
-    const parsed = lines.map(parseLine);
+    const parsed = lines.map((line, i) => parseLine(line, i, fileName));
 
     const results: { category: string; subjects: SubjectRecord[] }[] = [];
 


### PR DESCRIPTION
現在の実装ではCSVファイルをパースした際に「no subject」の扱いになった際に、コンソールへ以下のように出力される。

```bash
* no subject
* no subject
* no subject
* no subject
```

これはデバック等をする際に、不便であるため、コンソールへファイル名を出力するようにした。以下がその例である。

```bash
* no subject in file: 10400_41_142_24_1525.csv
* no subject in file: 10400_41_142_24_37.csv
* no subject in file: 10400_42_443_737_46.csv
* no subject in file: 10400_42_443_724_6335.csv